### PR TITLE
Use sprintf-js instead

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -7,6 +7,7 @@
 var _                   = require('lodash');
 var _s                  = require('underscore.string');
 var httpConst           = require('http-const');
+var sprintf             = require('sprintf-js').sprintf;
 var InvalidRequestError = require('./invalid-request-error');
 
 var CRLF = '\n';
@@ -32,7 +33,7 @@ function _generateStartLine(method, protocol, url, protocolVersion) {
     throw new InvalidRequestError('Method, url, protocol and protocolVersion must be not empty');
   }
   var newUrl = _s.ltrim(url, '/');
-  return _s.sprintf('%s %s://%s %s\n', method, protocol.toLowerCase(), newUrl, protocolVersion);
+  return sprintf('%s %s://%s %s\n', method, protocol.toLowerCase(), newUrl, protocolVersion);
 }
 
 function _generateHostLine(url) {
@@ -40,7 +41,7 @@ function _generateHostLine(url) {
   if (!host) {
     throw new InvalidRequestError('Host is undefined, requestUrl has invalid format');
   }  
-  return _s.sprintf('HOST: %s\n', host); 
+  return sprintf('HOST: %s\n', host); 
 }
 
 function _generateHeaders(headers) {
@@ -119,7 +120,7 @@ function _generateBody(body) {
         return [
           '-----------------------' + body.boundary,
           CRLF,
-          _s.sprintf('Content-Disposition: form-data; name="%s"', dataParam.name),
+          sprintf('Content-Disposition: form-data; name="%s"', dataParam.name),
           CRLF,
           CRLF,
           dataParam.value,
@@ -127,7 +128,7 @@ function _generateBody(body) {
         ].join('');
       }).join('');
       
-      return _s.sprintf('\n%s-----------------------%s--', formDataParams, body.boundary);
+      return sprintf('\n%s-----------------------%s--', formDataParams, body.boundary);
 
     case httpConst.contentTypes.xWwwFormUrlencoded:
       if (!body.formDataParams || !_.isArray(body.formDataParams) || !body.formDataParams.length) {
@@ -141,13 +142,13 @@ function _generateBody(body) {
         return dataParam.name + '=' + dataParam.value;
       }).join('&');
       
-      return _s.sprintf('\n%s', formDataParams);
+      return sprintf('\n%s', formDataParams);
 
     case httpConst.contentTypes.json:
       return '\n' + body.json;
       
     default:
-      return _s.sprintf('\n%s', body.plain);
+      return sprintf('\n%s', body.plain);
   }
 }
 

--- a/lib/invalid-request-error.js
+++ b/lib/invalid-request-error.js
@@ -4,13 +4,13 @@
  * MIT Licensed
  */
 
-var _s = require('underscore.string');
+var sprintf = require('sprintf-js').sprintf;
 
 function InvalidRequestError(message, data) {
   if (message) {
     this.message = data ? 
-    _s.sprintf('Invalid request object. %s. Data: %s', message, data) :
-    _s.sprintf('Invalid request object. %s', message);
+    sprintf('Invalid request object. %s. Data: %s', message, data) :
+    sprintf('Invalid request object. %s', message);
   } else {
     this.message = 'Invalid request object.'; 
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,172 @@
+{
+  "name": "http-request-builder",
+  "version": "1.2.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "http-const": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http-const/-/http-const-1.0.3.tgz",
+      "integrity": "sha1-zxVJbI9datRHC3HWWHGSK4RZ25s="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "should": {
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/should/-/should-4.6.5.tgz",
+      "integrity": "sha1-DRI0bbvRsCj59Lt6nVRzZPw2qH8=",
+      "dev": true
+    },
+    "should-equal": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
+      "integrity": "sha1-vY6pemdI45+tR2o75v1y68LnK/A=",
+      "dev": true
+    },
+    "should-format": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.0.7.tgz",
+      "integrity": "sha1-Hi74a9kdqcLgQSM1tWq6vZov3hI=",
+      "dev": true
+    },
+    "should-type": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.4.tgz",
+      "integrity": "sha1-ATKgVBemEmhmQmrPEW8e1WI6XNA=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "http-const": "^1.0.3",
     "lodash": "^3.1.0",
+    "sprintf-js": "^1.1.1",
     "underscore.string": "^3.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
As per epeli/underscore.string#479, the use of `underscore.string.sprintf` will be deprecated and recommends using [alexei/sprintf.js](https://github.com/alexei/sprintf.js) instead.. This removes the annoying DeprecationWarning.

Thanks for the repo by the way!